### PR TITLE
Add support for overriding the github url

### DIFF
--- a/request.ts
+++ b/request.ts
@@ -1,4 +1,4 @@
-const githubApiUrl = "https://api.github.com";
+const githubApiUrl = Deno.env.get("GITHUB_API_URL") ?? "https://api.github.com";
 
 export async function appRequest(
   jwt: string,


### PR DESCRIPTION
I tested locally with my github-enterprise url and it worked. Not specifying a url will safely fallback to the default without any errors.

Fixes #2 